### PR TITLE
feat: add reusable page sections

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,19 @@
+import React from "react";
 import CTAButton from "@/components/local/Button";
 import Header from "@/components/sections/Header";
-import React from "react";
+import Hero from "@/components/sections/Hero";
+import Contact from "@/components/sections/Contact";
+import Footer from "@/components/sections/Footer";
 
 export default function Page() {
   return (
     <div>
       <Header />
-      <CTAButton />
+      <Hero title="Accruwise" subtitle="Simple tools to manage your finances">
+        <CTAButton />
+      </Hero>
+      <Contact />
+      <Footer />
     </div>
   );
 }

--- a/src/components/local/NavMenu.tsx
+++ b/src/components/local/NavMenu.tsx
@@ -62,7 +62,7 @@ export function NavMenu() {
             <ul className="grid gap-2 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
               <li className="row-span-3">
                 <NavigationMenuLink asChild>
-                  <a
+                  <Link
                     className="from-muted/50 to-muted flex h-full w-full flex-col justify-end rounded-md bg-linear-to-b p-6 no-underline outline-hidden select-none focus:shadow-md"
                     href="/"
                   >
@@ -72,7 +72,7 @@ export function NavMenu() {
                     <p className="text-muted-foreground text-sm leading-tight">
                       Beautifully designed components built with Tailwind CSS.
                     </p>
-                  </a>
+                  </Link>
                 </NavigationMenuLink>
               </li>
               <ListItem href="/docs" title="Introduction">

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Button } from "@/components/ui/Button";
+
+interface ContactProps {
+  /** Optional heading for the contact section */
+  title?: string;
+  /** Callback fired with the form values when submitted */
+  onSubmit?: (values: {
+    name: string;
+    email: string;
+    message: string;
+  }) => void;
+}
+
+/**
+ * Simple contact form that collects a name, email and message.
+ * Consumers can handle submission via the `onSubmit` prop.
+ */
+export default function Contact({ title = "Contact Us", onSubmit }: ContactProps) {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const values = {
+      name: (formData.get("name") as string) ?? "",
+      email: (formData.get("email") as string) ?? "",
+      message: (formData.get("message") as string) ?? "",
+    };
+    onSubmit?.(values);
+    e.currentTarget.reset();
+  };
+
+  return (
+    <section className="mx-auto max-w-md p-4">
+      <h2 className="mb-4 text-2xl font-semibold">{title}</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          name="name"
+          placeholder="Name"
+          className="w-full rounded border p-2"
+        />
+        <input
+          name="email"
+          type="email"
+          placeholder="Email"
+          className="w-full rounded border p-2"
+        />
+        <textarea
+          name="message"
+          placeholder="Message"
+          className="h-32 w-full rounded border p-2"
+        />
+        <Button type="submit" className="w-full">
+          Send
+        </Button>
+      </form>
+    </section>
+  );
+}

--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+interface FooterProps {
+  /** Optional custom content to render inside the footer */
+  children?: React.ReactNode;
+}
+
+/**
+ * Basic footer component that displays provided children or a default
+ * copyright message.
+ */
+export default function Footer({ children }: FooterProps) {
+  return (
+    <footer className="border-t py-6 text-center text-sm text-muted-foreground">
+      {children ?? (
+        <p>&copy; {new Date().getFullYear()} Accruwise. All rights reserved.</p>
+      )}
+    </footer>
+  );
+}

--- a/src/components/sections/Header.tsx
+++ b/src/components/sections/Header.tsx
@@ -1,10 +1,24 @@
-import { NavMenu } from "@/components/local/NavMenu";
 import React from "react";
+import { NavMenu } from "@/components/local/NavMenu";
 
-export default function Header() {
+interface HeaderProps {
+  /**
+   * Optional content rendered on the left side of the header.
+   * This can be a logo or any React node.
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * Displays the global navigation for the site. The component accepts
+ * optional children which are placed to the left of the navigation menu,
+ * allowing consumers to easily inject a logo or other custom content.
+ */
+export default function Header({ children }: HeaderProps) {
   return (
-    <div>
+    <header className="flex items-center justify-between p-4">
+      {children}
       <NavMenu />
-    </div>
+    </header>
   );
 }

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+interface HeroProps {
+  /** Main headline for the hero section */
+  title: string;
+  /** Optional sub headline displayed below the title */
+  subtitle?: string;
+  /** Optional call to action or extra content */
+  children?: React.ReactNode;
+}
+
+/**
+ * A generic hero section that centers content and can display a title,
+ * subtitle and arbitrary children such as buttons.
+ */
+export default function Hero({ title, subtitle, children }: HeroProps) {
+  return (
+    <section className="px-4 py-24 text-center">
+      <h1 className="mb-4 text-4xl font-bold tracking-tight">{title}</h1>
+      {subtitle && (
+        <p className="mb-8 text-lg text-muted-foreground">{subtitle}</p>
+      )}
+      {children}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add configurable Hero, Contact, Footer and Header components
- integrate new sections into the main page
- fix NavMenu to use `next/link`

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`